### PR TITLE
Fixed globalvar/var/enum bounding

### DIFF
--- a/syntaxes/main/gml/gml-gms2.json
+++ b/syntaxes/main/gml/gml-gms2.json
@@ -68,7 +68,7 @@
          "name": "constant.language.gml"
       },
       {
-         "begin": "\\b((global)?var)\\b|(enum)\\b",
+         "begin": "\\b(((global)?var)|(enum))\\b",
          "beginCaptures": {
            "1": {
              "name": "storage.type.gml"

--- a/syntaxes/main/gml/gml-gms2.json
+++ b/syntaxes/main/gml/gml-gms2.json
@@ -68,7 +68,7 @@
          "name": "constant.language.gml"
       },
       {
-         "begin": "\\b((global)?var)|(enum)\\b",
+         "begin": "\\b((global)?var)\\b|(enum)\\b",
          "beginCaptures": {
            "1": {
              "name": "storage.type.gml"


### PR DESCRIPTION
Problem:
Word bounding for var or enum is badly defined, which matches things like <b><i>var</b></i>iable_instance_exists()

![image](https://user-images.githubusercontent.com/14203988/43053391-d226530c-8e02-11e8-8005-779ca8d1408c.png)

Hey, I don't know how to test this but it seems like it should get fixed with this. There are no contribution docs but it seemed like an easy fix, could you see if this works and if so publish it?
Thanks!